### PR TITLE
Fix firstname label and update translations

### DIFF
--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -36,7 +36,7 @@
                   <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "off", data: { "instant-attribute" => "name", "instant-recheck" => "#registration_user_password" } %>
                 </div>
                 <div class="field">
-                  <%= f.text_field :firstname, help_text: t(".user_firstname_help"), autocomplete: "off", data: { "instant-attribute" => "firstname", "instant-recheck" => "#registration_user_password" } %>
+                  <%= f.text_field :firstname, label: t(".firstname"), help_text: t(".user_firstname_help"), autocomplete: "off", data: { "instant-attribute" => "firstname", "instant-recheck" => "#registration_user_password" } %>
                 </div>
               </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
       registrations:
         new:
           already_have_an_account?: Already have an account?
+          firstname: Votre prénom
           newsletter: Receive an occasional newsletter with relevant information
           newsletter_title: Contact permission
           nickname: Nickname

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -95,6 +95,7 @@ fr:
       registrations:
         new:
           already_have_an_account?: Already have an account?
+          firstname: Votre prénom
           newsletter: Newsletter
           newsletter_title: Newsletter title
           nickname: Nickname


### PR DESCRIPTION
#### :tophat: Description
Replace the form label in english by a label that we can translate. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/P-v-le-Carembault-Probl-me-de-traduction-dans-le-formulaire-d-inscription-2e8c9a3e65ed42419d2d5ebd4a17771a?pvs=4)

#### Testing
Go to the sign up form and see that the firstname label is translated. 

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
<img width="623" alt="Capture d’écran 2023-07-27 à 10 28 47" src="https://github.com/OpenSourcePolitics/decidim-pvl/assets/52420208/2aa8bd6b-13ee-4462-9d3d-4cc57538992c">
